### PR TITLE
Add recycling robot backend and vision microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Reciclaje Robot Management
+
+Este proyecto contiene un backend en Node.js y un microservicio en Python para clasificar residuos mediante visión artificial.
+
+## Backend
+
+Las rutas principales están en `routes/api`. Los controladores se encuentran en `controllers/api`.
+
+Para iniciar el servidor Node:
+```bash
+npm install
+node app.js
+```
+
+## Microservicio de visión
+
+Dentro de `vision_service` se encuentra un pequeño servicio FastAPI que responde a `/classify`.
+
+Para ejecutarlo:
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```

--- a/app.js
+++ b/app.js
@@ -29,6 +29,10 @@ app.use(cookieParser());
 
 // LLAMAR AL router
 app.use("/", require("./routes/router"));
+app.use("/api/robots", require("./routes/api/robotRoutes"));
+app.use("/api/materiales", require("./routes/api/materialRoutes"));
+app.use("/api/cronograma", require("./routes/api/scheduleRoutes"));
+app.use("/api/resultados", require("./routes/api/resultRoutes"));
 
 /* app.get('/',(req, res) =>{
     res.render('index')

--- a/controllers/api/materialController.js
+++ b/controllers/api/materialController.js
@@ -1,0 +1,16 @@
+const conexion = require('../../database/db');
+
+exports.createMaterial = (req, res) => {
+  const data = req.body;
+  conexion.query('INSERT INTO materiales SET ?', data, (err) => {
+    if (err) return res.status(500).json({ error: err });
+    res.status(201).json({ message: 'Material registrado' });
+  });
+};
+
+exports.getMaterials = (_req, res) => {
+  conexion.query('SELECT * FROM materiales', (err, results) => {
+    if (err) return res.status(500).json({ error: err });
+    res.json(results);
+  });
+};

--- a/controllers/api/resultController.js
+++ b/controllers/api/resultController.js
@@ -1,0 +1,23 @@
+const axios = require('axios');
+const conexion = require('../../database/db');
+
+exports.classifyImage = async (req, res) => {
+  try {
+    const { imageUrl } = req.body;
+    const response = await axios.post('http://localhost:8000/classify', { image_url: imageUrl });
+    const result = response.data;
+    conexion.query('INSERT INTO resultados SET ?', { image_url: imageUrl, clasificacion: result.label }, (err) => {
+      if (err) return res.status(500).json({ error: err });
+      res.json(result);
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.getResults = (_req, res) => {
+  conexion.query('SELECT * FROM resultados', (err, results) => {
+    if (err) return res.status(500).json({ error: err });
+    res.json(results);
+  });
+};

--- a/controllers/api/robotController.js
+++ b/controllers/api/robotController.js
@@ -1,0 +1,16 @@
+const conexion = require('../../database/db');
+
+exports.createRobot = (req, res) => {
+  const data = req.body;
+  conexion.query('INSERT INTO robots SET ?', data, (err) => {
+    if (err) return res.status(500).json({ error: err });
+    res.status(201).json({ message: 'Robot creado' });
+  });
+};
+
+exports.getRobots = (_req, res) => {
+  conexion.query('SELECT * FROM robots', (err, results) => {
+    if (err) return res.status(500).json({ error: err });
+    res.json(results);
+  });
+};

--- a/controllers/api/scheduleController.js
+++ b/controllers/api/scheduleController.js
@@ -1,0 +1,16 @@
+const conexion = require('../../database/db');
+
+exports.createSchedule = (req, res) => {
+  const data = req.body;
+  conexion.query('INSERT INTO cronograma SET ?', data, (err) => {
+    if (err) return res.status(500).json({ error: err });
+    res.status(201).json({ message: 'Tarea agendada' });
+  });
+};
+
+exports.getSchedules = (_req, res) => {
+  conexion.query('SELECT * FROM cronograma', (err, results) => {
+    if (err) return res.status(500).json({ error: err });
+    res.json(results);
+  });
+};

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,33 @@
+-- Robots configuration
+CREATE TABLE IF NOT EXISTS robots (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(50),
+  modelo VARCHAR(50),
+  parametros JSON
+);
+
+-- Materials to recycle
+CREATE TABLE IF NOT EXISTS materiales (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  tipo VARCHAR(50),
+  estado VARCHAR(20),
+  cantidad DECIMAL(10,2)
+);
+
+-- Cronograma de reciclaje
+CREATE TABLE IF NOT EXISTS cronograma (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  robot_id INT,
+  material_id INT,
+  fecha DATETIME,
+  FOREIGN KEY (robot_id) REFERENCES robots(id),
+  FOREIGN KEY (material_id) REFERENCES materiales(id)
+);
+
+-- Resultados de clasificacion
+CREATE TABLE IF NOT EXISTS resultados (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  image_url VARCHAR(255),
+  clasificacion VARCHAR(50),
+  fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "express-session": "^1.18.1",
     "jsonwebtoken": "^9.0.2",
     "mysql": "^2.18.1",
-    "nodemon": "^3.1.7"
+    "nodemon": "^3.1.7",
+    "axios": "^1.6.2"
   }
 }

--- a/routes/api/materialRoutes.js
+++ b/routes/api/materialRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/api/materialController');
+
+router.post('/', ctrl.createMaterial);
+router.get('/', ctrl.getMaterials);
+
+module.exports = router;

--- a/routes/api/resultRoutes.js
+++ b/routes/api/resultRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/api/resultController');
+
+router.post('/classify', ctrl.classifyImage);
+router.get('/', ctrl.getResults);
+
+module.exports = router;

--- a/routes/api/robotRoutes.js
+++ b/routes/api/robotRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/api/robotController');
+
+router.post('/', ctrl.createRobot);
+router.get('/', ctrl.getRobots);
+
+module.exports = router;

--- a/routes/api/scheduleRoutes.js
+++ b/routes/api/scheduleRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/api/scheduleController');
+
+router.post('/', ctrl.createSchedule);
+router.get('/', ctrl.getSchedules);
+
+module.exports = router;

--- a/vision_service/main.py
+++ b/vision_service/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from random import choice
+
+app = FastAPI()
+
+class ImageRequest(BaseModel):
+    image_url: str
+
+LABELS = ['plastico', 'vidrio', 'metal', 'papel']
+
+@app.post('/classify')
+def classify(req: ImageRequest):
+    # Aqui se integraria el modelo de IA real
+    label = choice(LABELS)
+    return {'label': label}

--- a/vision_service/requirements.txt
+++ b/vision_service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pillow


### PR DESCRIPTION
## Summary
- add API routes and controllers for robots, materials, schedules and results
- wire new API routes in `app.js`
- add axios dependency
- provide SQL schema for MySQL tables
- create FastAPI microservice skeleton for image classification
- include basic README with usage info

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`
- `npm install axios` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68435135ff288329bb2bee9e444b0071